### PR TITLE
OSOE-482: Enforce parameter splatting instead of backtick in Lombiq.Analyzers.PowerShell

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -16,9 +16,8 @@ jobs:
     runs-on: ${{ matrix.machine-type }}
 
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
+      - name: Checkout
+        uses: Lombiq/GitHub-Actions/.github/actions/checkout@dev
 
       - name: Windows PowerShell Static Code Analysis (Windows-only)
         if: runner.os == 'Windows'

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -20,19 +20,19 @@ jobs:
     runs-on: ${{ matrix.machine-type }}
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
-    
-    - name: Windows PowerShell Static Code Analysis
-      run: |
-        if ($Env:RUNNER_OS -ne 'Windows') 
-        {
-            Write-Output "This step is only for Windows. The current runner is $Env:RUNNER_OS so it's skipped."
-            exit 0
-        }
-        powershell .\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions
-    
-    - name: PowerShell 7+ Static Code Analysis
-      if: always() # Even if the above fails, let's check both.
-      run: .\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+
+      - name: Windows PowerShell Static Code Analysis
+        run: |
+          if ($Env:RUNNER_OS -ne 'Windows') 
+          {
+              Write-Output "This step is only for Windows. The current runner is $Env:RUNNER_OS so it's skipped."
+              exit 0
+          }
+          powershell .\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions
+
+      - name: PowerShell 7+ Static Code Analysis
+        if: always() # Even if the above fails, let's check both.
+        run: .\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -7,10 +7,6 @@ on:
     branches:
       - dev
 
-defaults:
-  run:
-    shell: pwsh
-
 jobs:
   powershell-static-code-analysis:
     name: PowerShell Static Code Analysis
@@ -24,15 +20,12 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Windows PowerShell Static Code Analysis
-        run: |
-          if ($Env:RUNNER_OS -ne 'Windows') 
-          {
-              Write-Output "This step is only for Windows. The current runner is $Env:RUNNER_OS so it's skipped."
-              exit 0
-          }
-          powershell .\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions
+      - name: Windows PowerShell Static Code Analysis (Windows-only)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: .\Utility\tools\Lombiq.Analyzers.PowerShell\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions
 
       - name: PowerShell 7+ Static Code Analysis
         if: always() # Even if the above fails, let's check both.
-        run: .\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions
+        shell: pwsh
+        run: .\Utility\tools\Lombiq.Analyzers.PowerShell\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Windows PowerShell Static Code Analysis (Windows-only)
         if: runner.os == 'Windows'
         shell: powershell
-        run: .\Utility\tools\Lombiq.Analyzers.PowerShell\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions
+        run: .\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions
 
       - name: PowerShell 7+ Static Code Analysis
         if: always() # Even if the above fails, let's check both.
         shell: pwsh
-        run: .\Utility\tools\Lombiq.Analyzers.PowerShell\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions
+        run: .\Lombiq.Analyzers.PowerShell\Invoke-Analyzer.ps1 -ForGitHubActions

--- a/.github/workflows/test-analysis-failure.yml
+++ b/.github/workflows/test-analysis-failure.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   call-test-analysis-failure-nuget:
     name: Test Analysis Failure - NuGet PackageReference
+    if: ${{ false }}
     uses: Lombiq/GitHub-Actions/.github/workflows/test-analysis-failure.yml@dev
     with:
       machine-types: "[\"ubuntu-latest\", \"windows-latest\"]"

--- a/.github/workflows/test-analysis-failure.yml
+++ b/.github/workflows/test-analysis-failure.yml
@@ -10,10 +10,10 @@ on:
 jobs:
   call-test-analysis-failure-nuget:
     name: Test Analysis Failure - NuGet PackageReference
-    if: ${{ false }}
+    if: false
     uses: Lombiq/GitHub-Actions/.github/workflows/test-analysis-failure.yml@dev
     with:
-      machine-types: "[\"ubuntu-latest\", \"windows-latest\"]"
+      machine-types: "['ubuntu-latest', 'windows-latest']"
       build-directory: TestSolutions/Lombiq.Analyzers.PowerShell.PackageReference
       timeout-minutes: 30
       build-expected-code-analysis-errors: |
@@ -29,7 +29,7 @@ jobs:
     name: Test Analysis Failure - Local ProjectReference
     uses: Lombiq/GitHub-Actions/.github/workflows/test-analysis-failure.yml@dev
     with:
-      machine-types: "[\"ubuntu-latest\", \"windows-latest\"]"
+      machine-types: "['ubuntu-latest', 'windows-latest']"
       build-directory: TestSolutions/Lombiq.Analyzers.PowerShell.ProjectReference
       timeout-minutes: 30
       build-expected-code-analysis-errors: |

--- a/.github/workflows/test-analysis-failure.yml
+++ b/.github/workflows/test-analysis-failure.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   call-test-analysis-failure-nuget:
     name: Test Analysis Failure - NuGet PackageReference
-    if: false
     uses: Lombiq/GitHub-Actions/.github/workflows/test-analysis-failure.yml@dev
     with:
       machine-types: "['ubuntu-latest', 'windows-latest']"

--- a/.github/workflows/test-analysis-failure.yml
+++ b/.github/workflows/test-analysis-failure.yml
@@ -20,6 +20,7 @@ jobs:
         PSAvoidUsingAutomaticVariableAlias: '$_' is an alias of '$PSItem'.
         PSAvoidUsingCmdletAliases: '%' is an alias of 'ForEach-Object'.
         PSAvoidUsingEmptyCatchBlock: Empty catch block is used.
+        PSAvoidUsingLineContinuation: Using backtick (line continuation) makes the code harder to read and maintain.
         PSUseApprovedVerbs: The cmdlet 'Violate-Analyzers' uses an unapproved verb.
         PSUseSingularNouns: The cmdlet 'Violate-Analyzers' uses a plural noun.
 
@@ -35,5 +36,6 @@ jobs:
         PSAvoidUsingAutomaticVariableAlias: '$_' is an alias of '$PSItem'.
         PSAvoidUsingCmdletAliases: '%' is an alias of 'ForEach-Object'.
         PSAvoidUsingEmptyCatchBlock: Empty catch block is used.
+        PSAvoidUsingLineContinuation: Using backtick (line continuation) makes the code harder to read and maintain.
         PSUseApprovedVerbs: The cmdlet 'Violate-Analyzers' uses an unapproved verb.
         PSUseSingularNouns: The cmdlet 'Violate-Analyzers' uses a plural noun.

--- a/Lombiq.Analyzers.PowerShell.Tests/UnitTests/PowerShellAnalysisTests.cs
+++ b/Lombiq.Analyzers.PowerShell.Tests/UnitTests/PowerShellAnalysisTests.cs
@@ -54,6 +54,7 @@ public class PowerShellAnalysisTests
         message.ShouldContain("PSAvoidUsingAutomaticVariableAlias");
         message.ShouldContain("PSAvoidUsingCmdletAliases");
         message.ShouldContain("PSAvoidUsingEmptyCatchBlock");
+        message.ShouldContain("PSAvoidUsingLineContinuation");
         message.ShouldContain("PSUseApprovedVerbs");
         message.ShouldContain("PSUseSingularNouns");
     }

--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -91,11 +91,11 @@ if ((Get-InstalledModule PSScriptAnalyzer -ErrorAction SilentlyContinue).Version
 }
 
 $analyzerParameters = @{
-    "Settings"              = $SettingsPath.FullName
-    "CustomRulePath"        = Join-Path -Path (Split-Path $MyInvocation.MyCommand.Path -Parent) -ChildPath Rules
+    "Settings" = $SettingsPath.FullName
+    "CustomRulePath" = Join-Path -Path (Split-Path $MyInvocation.MyCommand.Path -Parent) -ChildPath Rules
     "RecurseCustomRulePath" = $true
-    "IncludeDefaultRules"   = $true
-    "Fix"                   = $Fix
+    "IncludeDefaultRules" = $true
+    "Fix" = $Fix
 }
 $results = Find-Recursively -IncludeFile "*.ps1", "*.psm1", "*.psd1" -ExcludeDirectory node_modules |
     Where-Object { # Exclude /TestSolutions/Violate-Analyzers.ps1 and /TestSolutions/*/Violate-Analyzers.ps1

--- a/Lombiq.Analyzers.PowerShell/Rules/Measure-AutomaticVariableAlias/LICENSE
+++ b/Lombiq.Analyzers.PowerShell/Rules/Measure-AutomaticVariableAlias/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Lombiq.Analyzers.PowerShell/Rules/Measure-AutomaticVariableAlias/Measure-AutomaticVariableAlias.psm1
+++ b/Lombiq.Analyzers.PowerShell/Rules/Measure-AutomaticVariableAlias/Measure-AutomaticVariableAlias.psm1
@@ -10,8 +10,7 @@
 .OUTPUTS
     [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]]
 .NOTES
-    Copied (and modified) version of
-    https://github.com/PowerShell/PSScriptAnalyzer/blob/master/Tests/Engine/CommunityAnalyzerRules/CommunityAnalyzerRules.psm1#L613.
+    Inspired by https://github.com/PowerShell/PSScriptAnalyzer/blob/master/Tests/Engine/CommunityAnalyzerRules/CommunityAnalyzerRules.psm1#L613.
 #>
 function Measure-AutomaticVariableAlias
 {
@@ -48,12 +47,12 @@ function Measure-AutomaticVariableAlias
                 $suggestedCorrections.add($correctionExtent) | Out-Null
 
                 $results += [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
-                    "Extent"               = $automaticVariableAliasToken.Extent
-                    "Message"              = '''$_'' is an alias of the automatic variable ''$PSItem''. Please consider using the full name of this' +
+                    "Extent" = $automaticVariableAliasToken.Extent
+                    "Message" = '''$_'' is an alias of the automatic variable ''$PSItem''. Please consider using the full name of this' +
                     ' variable for consistency.'
-                    "RuleName"             = "PSAvoidUsingAutomaticVariableAlias"
-                    "RuleSuppressionID"    = "PSAvoidUsingAutomaticVariableAlias"
-                    "Severity"             = "Warning"
+                    "RuleName" = "PSAvoidUsingAutomaticVariableAlias"
+                    "RuleSuppressionID" = "PSAvoidUsingAutomaticVariableAlias"
+                    "Severity" = "Warning"
                     "SuggestedCorrections" = $suggestedCorrections
                 }
             }

--- a/Lombiq.Analyzers.PowerShell/Rules/Measure-LineContinuation/LICENSE
+++ b/Lombiq.Analyzers.PowerShell/Rules/Measure-LineContinuation/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Lombiq.Analyzers.PowerShell/Rules/Measure-LineContinuation/Measure-LineContinuation.psm1
+++ b/Lombiq.Analyzers.PowerShell/Rules/Measure-LineContinuation/Measure-LineContinuation.psm1
@@ -38,12 +38,12 @@ function Measure-LineContinuation
                     $PSItem.Kind -eq [System.Management.Automation.Language.TokenKind]::LineContinuation })
             {
                 $results += [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
-                    "Extent"            = $lineContinuationToken.Extent
-                    "Message"           = 'Using backtick (line continuation) makes the code harder to read and' +
+                    "Extent" = $lineContinuationToken.Extent
+                    "Message" = 'Using backtick (line continuation) makes the code harder to read and' +
                     ' maintain. Please consider using parameter splatting instead.'
-                    "RuleName"          = "PSAvoidUsingLineContinuation"
+                    "RuleName" = "PSAvoidUsingLineContinuation"
                     "RuleSuppressionID" = "PSAvoidUsingLineContinuation"
-                    "Severity"          = "Warning"
+                    "Severity" = "Warning"
                 }
             }
 

--- a/Lombiq.Analyzers.PowerShell/Rules/Measure-LineContinuation/Measure-LineContinuation.psm1
+++ b/Lombiq.Analyzers.PowerShell/Rules/Measure-LineContinuation/Measure-LineContinuation.psm1
@@ -34,16 +34,16 @@ function Measure-LineContinuation
 
         try
         {
-            foreach ($lineContinuationToken in $Token
-                | Where-Object { $PSItem.Kind -eq [System.Management.Automation.Language.TokenKind]::LineContinuation })
+            foreach ($lineContinuationToken in $Token | Where-Object {
+                    $PSItem.Kind -eq [System.Management.Automation.Language.TokenKind]::LineContinuation })
             {
                 $results += [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
-                    "Extent"               = $lineContinuationToken.Extent
-                    "Message"              = 'Using backtick (line continuation) makes the code harder to read and' +
+                    "Extent"            = $lineContinuationToken.Extent
+                    "Message"           = 'Using backtick (line continuation) makes the code harder to read and' +
                     ' maintain. Please consider using parameter splatting instead.'
-                    "RuleName"             = "PSAvoidUsingLineContinuation"
-                    "RuleSuppressionID"    = "PSAvoidUsingLineContinuation"
-                    "Severity"             = "Warning"
+                    "RuleName"          = "PSAvoidUsingLineContinuation"
+                    "RuleSuppressionID" = "PSAvoidUsingLineContinuation"
+                    "Severity"          = "Warning"
                 }
             }
 

--- a/Lombiq.Analyzers.PowerShell/Rules/Measure-LineContinuation/Measure-LineContinuation.psm1
+++ b/Lombiq.Analyzers.PowerShell/Rules/Measure-LineContinuation/Measure-LineContinuation.psm1
@@ -1,0 +1,54 @@
+<#
+.SYNOPSIS
+    Removes backticks from your script and use "splatting" instead.
+.DESCRIPTION
+    In general, the community feels you should avoid using those backticks as “line continuation characters” when possible.
+    They’re hard to read, easy to miss, and easy to mis-type. Also, if you add an extra whitespace after the backtick in the above example, then the command won’t work.
+    To fix a violation of this rule, please remove backticks from your script and use "splatting" instead. You can run "Get-Help about_splatting" to get more details.
+.EXAMPLE
+    Measure-Backtick -Token $Token
+.INPUTS
+    [System.Management.Automation.Language.Token[]]
+.OUTPUTS
+    [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]]
+.NOTES
+    Reference: Document nested structures, Windows PowerShell Best Practices.
+#>
+function Measure-Backtick
+{
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.Token[]]
+        $Token
+    )
+
+    Process
+    {
+        $results = @()
+
+        try
+        {
+            # Finds LineContinuation tokens
+            $lcTokens = $Token | Where-Object {$PSItem.Kind -eq [System.Management.Automation.Language.TokenKind]::LineContinuation}
+
+            foreach ($lcToken in $lcTokens)
+            {
+                $result = New-Object `
+                            -Typename "Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord" `
+                            -ArgumentList $Messages.MeasureBacktick,$lcToken.Extent,$PSCmdlet.MyInvocation.InvocationName,Warning,$null
+
+                $results += $result
+            }
+
+            return $results
+        }
+        catch
+        {
+            $PSCmdlet.ThrowTerminatingError($PSItem)
+        }
+    }
+}

--- a/TestSolutions/Lombiq.Analyzers.PowerShell.PackageReference/Lombiq.Analyzers.PowerShell.PackageReference.csproj
+++ b/TestSolutions/Lombiq.Analyzers.PowerShell.PackageReference/Lombiq.Analyzers.PowerShell.PackageReference.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lombiq.Analyzers.PowerShell" Version="1.1.0-beta.1.osoe-472" />
+    <PackageReference Include="Lombiq.Analyzers.PowerShell" Version="1.2.0-beta.0.osoe-482" />
   </ItemGroup>
 
   <Target Name="CopyFiles" BeforeTargets="PrepareForBuild">

--- a/TestSolutions/Violate-Analyzers.ps1
+++ b/TestSolutions/Violate-Analyzers.ps1
@@ -5,4 +5,5 @@ function Violate-Analyzers()
 
 try { Violate-Analyzers } catch { }
 
-Get-ChildItem . | % { $_ }
+"Lombiq", `
+"Orchard", "Hastlayer" | % { $_ }


### PR DESCRIPTION
[OSOE-482](https://lombiq.atlassian.net/browse/OSOE-482)
Fixes #14