### PR TITLE
OSOE-528: PSReviewUnusedParameter in-place suppression instead of disabling the rule

### DIFF
--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -1,4 +1,16 @@
-﻿param(
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter',
+    'ForGitHubActions',
+    Justification = 'False positive due to https://github.com/PowerShell/PSScriptAnalyzer/issues/1472.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter',
+    'ForMsBuild',
+    Justification = 'False positive due to https://github.com/PowerShell/PSScriptAnalyzer/issues/1472.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter',
+    'IncludeTestSolutions',
+    Justification = 'False positive due to https://github.com/PowerShell/PSScriptAnalyzer/issues/1472.')]
+param(
     $SettingsPath = (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) 'PSScriptAnalyzerSettings.psd1'),
     [Switch] $ForGitHubActions,
     [Switch] $ForMsBuild,

--- a/Lombiq.Analyzers.PowerShell/PSScriptAnalyzerSettings.psd1
+++ b/Lombiq.Analyzers.PowerShell/PSScriptAnalyzerSettings.psd1
@@ -3,10 +3,6 @@
     @(
         # This rule expects us to implement a feature we will be unlikely to use in the majority of cases. Although
         # ShouldProcess support should be implemented in cases where it makes sense.
-        'PSUseShouldProcessForStateChangingFunctions',
-        # This rule causes too many false positives because parameters that are only used in script blocks are
-        # considered unused. It should be re-enabled once https://github.com/PowerShell/PSScriptAnalyzer/issues/1472 is
-        # resolved.
-        'PSReviewUnusedParameter'
+        'PSUseShouldProcessForStateChangingFunctions'
     )
 }


### PR DESCRIPTION
[OSOE-528](https://lombiq.atlassian.net/browse/OSOE-528)
Fixes #18

[OSOE-528]: https://lombiq.atlassian.net/browse/OSOE-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ