### PR TITLE
OSOE-560: Add retries workflow for Invoke-ScriptAnalyzer

### DIFF
--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -111,31 +111,31 @@ $analyzerParameters = @{
     IncludeDefaultRules = $true
     Fix = $Fix
 }
-$maxRetries = 3
 $results = Find-Recursively -IncludeFile '*.ps1', '*.psm1', '*.psd1' -ExcludeDirectory node_modules |
     Where-Object { # Exclude /TestSolutions/Violate-Analyzers.ps1 and /TestSolutions/*/Violate-Analyzers.ps1
         $IncludeTestSolutions -or -not (
             $PSItem.Name -eq 'Violate-Analyzers.ps1' -and
             ($PSItem.Directory.Name -eq 'TestSolutions' -or $PSItem.Directory.Parent.Name -eq 'TestSolutions')) } |
     ForEach-Object {
-        $retryCount = 0
-        while ($retryCount -lt $maxRetries)
+        $maxRetries = 3
+        for ($retryCount = 0; $retryCount -lt $maxRetries; $retryCount++)
         {
             try
             {
-                Invoke-ScriptAnalyzer -Path $PSItem.FullName @analyzerParameters
+                $extendedAnalyzerParameters = $analyzerParameters.Clone()
+                $extendedAnalyzerParameters.Verbose = $retryCount -ge 1
+                Invoke-ScriptAnalyzer -Path $PSItem.FullName @extendedAnalyzerParameters
                 break
             }
             catch
             {
-                $retryCount++
-                if ($retryCount -eq $maxRetries)
+                if ($retryCount -eq ($maxRetries - 1))
                 {
                     Write-Error "Failed to analyze $($PSItem.FullName) after $maxRetries attempts. Exception: $_"
                 }
                 else
                 {
-                    Write-Error "Retry #$($retryCount): An exception occurred: $_. Retrying..."
+                    Write-Error "Retry #$($retryCount + 1): An exception occurred: $_. Retrying..."
                 }
             }
         }


### PR DESCRIPTION
[OSOE-560](https://lombiq.atlassian.net/browse/OSOE-560)
The solution included in this PR implements a maximum of 3 retries per file when they cause an exception at the following statement:

`Invoke-ScriptAnalyzer -Path $PSItem.FullName @analyzerParameters`
Fixes #28

[OSOE-560]: https://lombiq.atlassian.net/browse/OSOE-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ