### PR TITLE
OSOE-743: Cancel ongoing runs of long-running workflows under a PR when new changes are pushed, vol.2

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -67,8 +67,8 @@ jobs:
       group: |
         ${{
           inputs.cancel-in-progress-for-this-pr == 'true' && github.event_name == 'pull_request'
-            && format('{0}_{1}_{2}', github.workflow, github.ref, matrix.machine-type)
-            || format('{0}_{1}', github.run_id, matrix.machine-type)
+            && format('{0}_powershell-static-code-analysis_{1}_{2}', github.workflow, github.ref, matrix.machine-type)
+            || format('{0}_powershell-static-code-analysis_{1}', github.run_id, matrix.machine-type)
         }}
       cancel-in-progress: ${{ inputs.cancel-in-progress-for-this-pr == 'true' }}
     steps:

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -63,7 +63,8 @@ jobs:
       # key will be constructed from a handful of parameters to produce a value that would evaluate to the same value on
       # a subsequent push, causing the already running workflow for this pull request (in this repository) to be
       # cancelled. Otherwise it will be the ID of the workflow run and the machine type, making it more unique and not
-      # cancel anything.
+      # cancel anything. A technical name for this workflow is also included in both cases, so that it doesn't come into
+      # conflict with other jobs calling a different workflow that are started by the same caller workflow.
       group: |
         ${{
           inputs.cancel-in-progress-for-this-pr == 'true' && github.event_name == 'pull_request'


### PR DESCRIPTION
[OSOE-743](https://lombiq.atlassian.net/browse/OSOE-743)
The change is to prevent this from happening: https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/actions/runs/7119645194?pr=630

[OSOE-743]: https://lombiq.atlassian.net/browse/OSOE-743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ