### PR TITLE
OSOE-875: Analyzer violations don't show files and lines when run in GitHub Actions

### DIFF
--- a/.github/workflows/static-code-analysis-this-repo.yml
+++ b/.github/workflows/static-code-analysis-this-repo.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   powershell-static-code-analysis:
     name: PowerShell Static Code Analysis
-    uses: Lombiq/PowerShell-Analyzers/.github/workflows/static-code-analysis.yml@dev
+    uses: Lombiq/PowerShell-Analyzers/.github/workflows/static-code-analysis.yml@issue/OSOE-875
     with:
       # Making sure that analysis runs through both PowerShell editions regardless of the default configuration of the
       # workflow and the underlying action to ensure backwards-compatibility.

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -79,7 +79,7 @@ jobs:
           token: ${{ secrets.CHECKOUT_TOKEN }}
 
       - name: PowerShell Static Code Analysis
-        uses: Lombiq/PowerShell-Analyzers/.github/actions/static-code-analysis@dev
+        uses: Lombiq/PowerShell-Analyzers/.github/actions/static-code-analysis@issue/OSOE-875
         with:
           run-windows-powershell: ${{ inputs.run-windows-powershell }}
           run-powershell-core: ${{ inputs.run-powershell-core }}

--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -49,7 +49,7 @@ function Write-FileError([string] $Message, [string] $Path, [int] $Line = 0, [in
     if ($ForGitHubActions)
     {
         $Message = $Message -replace '\s*(\r?\n\s*)+', ' '
-        Write-Output "::error::$(if ($Path) { "$Path($Line,$Column): " })$Message)"
+        Write-Output "::error::$(if ($Path) { "$Path($Line,$Column): " })$Message"
     }
     elseif ($ForMsBuild)
     {

--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -44,13 +44,14 @@ function Find-Recursively([string] $Path = '.', [string[]] $IncludeFile, [string
 
 function Write-FileError([string] $Message, [string] $Path, [int] $Line = 0, [int] $Column = 0)
 {
-    if ($Path) { $Path = Get-Item $Path }
+    if ($Path) { $Path = Get-Item $Path } 
 
     if ($ForGitHubActions)
     {
         $Message = $Message -replace '\s*(\r?\n\s*)+', ' '
         Write-Output "::error::$(if ($Path) { "$(Resolve-Path -Relative -Path $Path)($Line,$Column): " })$Message"
     }
+    
     elseif ($ForMsBuild)
     {
         if (-not $Message.Contains(':')) { $Message = ": $Message" }

--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -49,7 +49,7 @@ function Write-FileError([string] $Message, [string] $Path, [int] $Line = 0, [in
     if ($ForGitHubActions)
     {
         $Message = $Message -replace '\s*(\r?\n\s*)+', ' '
-        Write-Output "::error$(if ($Path) { " file=$Path,line=$Line,col=$Column::$Message" } else { "::$Message" })"
+        Write-Output "::error$(if ($Path) { " title=$Path (Line: $Line; Column: $Column)::$Message" } else { "::$Message" })"
     }
     elseif ($ForMsBuild)
     {

--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -44,7 +44,14 @@ function Find-Recursively([string] $Path = '.', [string[]] $IncludeFile, [string
 
 function Write-FileError([string] $Message, [string] $Path, [int] $Line = 0, [int] $Column = 0)
 {
+    Write-Output "::error::This is Path: $Path"
+    $relativePath = Resolve-Path -Relative -Path $Path
+    Write-Output "::error::This is relativePath: $relativePath"
+
     if ($Path) { $Path = Get-Item $Path }
+
+    $relativePath = Resolve-Path -Relative -Path $Path
+    Write-Output "::error::This is relativePath after Get-Item: $relativePath"
 
     if ($ForGitHubActions)
     {

--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -44,14 +44,7 @@ function Find-Recursively([string] $Path = '.', [string[]] $IncludeFile, [string
 
 function Write-FileError([string] $Message, [string] $Path, [int] $Line = 0, [int] $Column = 0)
 {
-    Write-Output "::error::This is Path: $Path"
-    $relativePath = Resolve-Path -Relative -Path $Path
-    Write-Output "::error::This is relativePath: $relativePath"
-
     if ($Path) { $Path = Get-Item $Path }
-
-    $relativePath = Resolve-Path -Relative -Path $Path
-    Write-Output "::error::This is relativePath after Get-Item: $relativePath"
 
     if ($ForGitHubActions)
     {

--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -44,14 +44,13 @@ function Find-Recursively([string] $Path = '.', [string[]] $IncludeFile, [string
 
 function Write-FileError([string] $Message, [string] $Path, [int] $Line = 0, [int] $Column = 0)
 {
-    if ($Path) { $Path = Get-Item $Path } 
+    if ($Path) { $Path = Get-Item $Path }
 
     if ($ForGitHubActions)
     {
         $Message = $Message -replace '\s*(\r?\n\s*)+', ' '
         Write-Output "::error::$(if ($Path) { "$(Resolve-Path -Relative -Path $Path)($Line,$Column): " })$Message"
     }
-    
     elseif ($ForMsBuild)
     {
         if (-not $Message.Contains(':')) { $Message = ": $Message" }

--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -49,7 +49,7 @@ function Write-FileError([string] $Message, [string] $Path, [int] $Line = 0, [in
     if ($ForGitHubActions)
     {
         $Message = $Message -replace '\s*(\r?\n\s*)+', ' '
-        Write-Output "::error::$Message $(if ($Path) { "(Path: $Path; Line: $Line; Column: $Column)" })"
+        Write-Output "::error::$(if ($Path) { "$Path($Line,$Column): " })$Message)"
     }
     elseif ($ForMsBuild)
     {

--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -49,7 +49,7 @@ function Write-FileError([string] $Message, [string] $Path, [int] $Line = 0, [in
     if ($ForGitHubActions)
     {
         $Message = $Message -replace '\s*(\r?\n\s*)+', ' '
-        Write-Output "::error::$(if ($Path) { "$Path($Line,$Column): " })$Message"
+        Write-Output "::error::$(if ($Path) { "$(Resolve-Path -Relative -Path $Path)($Line,$Column): " })$Message"
     }
     elseif ($ForMsBuild)
     {

--- a/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
+++ b/Lombiq.Analyzers.PowerShell/Invoke-Analyzer.ps1
@@ -49,7 +49,7 @@ function Write-FileError([string] $Message, [string] $Path, [int] $Line = 0, [in
     if ($ForGitHubActions)
     {
         $Message = $Message -replace '\s*(\r?\n\s*)+', ' '
-        Write-Output "::error$(if ($Path) { " title=$Path (Line: $Line; Column: $Column)::$Message" } else { "::$Message" })"
+        Write-Output "::error::$Message $(if ($Path) { "(Path: $Path; Line: $Line; Column: $Column)" })"
     }
     elseif ($ForMsBuild)
     {

--- a/TestSolutions/Lombiq.Analyzers.PowerShell.PackageReference/Lombiq.Analyzers.PowerShell.PackageReference.csproj
+++ b/TestSolutions/Lombiq.Analyzers.PowerShell.PackageReference/Lombiq.Analyzers.PowerShell.PackageReference.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lombiq.Analyzers.PowerShell" Version="1.4.0" />
+    <PackageReference Include="Lombiq.Analyzers.PowerShell" Version="1.4.1-alpha.0.osoe-875" />
   </ItemGroup>
 
   <Target Name="CopyFiles" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
[OSOE-875](https://lombiq.atlassian.net/browse/OSOE-875)
Fixes #43

Example violation build output: https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/actions/runs/9780958471/job/27004283503?pr=804

[OSOE-875]: https://lombiq.atlassian.net/browse/OSOE-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ