### PR TITLE
OSOE-538: Enable PSAlignAssignmentStatement analyzer rule in Lombiq.Analyzers.PowerShell

### DIFF
--- a/Lombiq.Analyzers.PowerShell/PSScriptAnalyzerSettings.psd1
+++ b/Lombiq.Analyzers.PowerShell/PSScriptAnalyzerSettings.psd1
@@ -52,5 +52,9 @@
         PSUseCorrectCasing = @{
             Enable = $true
         }
+	PSAlignAssignmentStatement = @{
+	    Enable = $true
+            CheckHashtable = $true
+	}
     }
 }

--- a/Lombiq.Analyzers.PowerShell/PSScriptAnalyzerSettings.psd1
+++ b/Lombiq.Analyzers.PowerShell/PSScriptAnalyzerSettings.psd1
@@ -52,9 +52,9 @@
         PSUseCorrectCasing = @{
             Enable = $true
         }
-	PSAlignAssignmentStatement = @{
-	    Enable = $true
+        PSAlignAssignmentStatement = @{
+            Enable = $true
             CheckHashtable = $true
-	}
+        }
     }
 }

--- a/TestSolutions/Violate-Analyzers.ps1
+++ b/TestSolutions/Violate-Analyzers.ps1
@@ -10,3 +10,8 @@ try { Violate-Analyzers } catch { }
 
 "Lombiq", `
 'Orchard', 'Hastlayer' | % { $_ }
+
+$hashtable = @{
+    property1 = 'Lombiq'
+    anotherProperty = 'Orchard'
+}


### PR DESCRIPTION
[OSOE-538](https://lombiq.atlassian.net/browse/OSOE-538)
Fixes #21